### PR TITLE
Detailed status assertions

### DIFF
--- a/draft-demarco-oauth-status-assertions.md
+++ b/draft-demarco-oauth-status-assertions.md
@@ -732,8 +732,8 @@ An example of an enumeration status is:
     "exp": 1504785536,
     "credential_hash": "xnlAq6Ma8fgu1z4hdGphJnKLulaVHpLCFeZFUGpQ2dA",
     "credential_hash_alg": "sha-256",
-    "validity": false,
-    "validity_reasons": {
+    "credential_status_validity": false,
+    "credential_status": {
       "state": "suspended", // or "revoked"
     },
     "cnf": {
@@ -764,8 +764,8 @@ An example of dynamic status using a small matrix:
     "exp": 1504785536,
     "credential_hash": "xnlAq6Ma8fgu1z4hdGphJnKLulaVHpLCFeZFUGpQ2dA",
     "credential_hash_alg": "sha-256",
-    "validity": true,
-    "validity_reasons": {
+    "credential_status_validity": true,
+    "credential_status": {
       "preferences": [[1, 0.25, 0.76 ...] ...]
     },
     "cnf": {

--- a/draft-demarco-oauth-status-assertions.md
+++ b/draft-demarco-oauth-status-assertions.md
@@ -676,7 +676,7 @@ may not always coincide with the actual usability of a Digital Credential,
 allowing Verifiers to examine and make educated conclusions based on a
 variety of scenarios.
 
-# Complex Status Assertions
+# Detailed Status Assertions
 
 Status assertions can be complex, and are not limited to simple boolean information.
 This enables verifier policies to be conditioned on the presence of secured information, instead of the absence of information.

--- a/draft-demarco-oauth-status-assertions.md
+++ b/draft-demarco-oauth-status-assertions.md
@@ -248,7 +248,7 @@ the expiration datetime of the Digital Credential;
 - MUST enable the offline use cases by employing validation using
 a cryptographic signature and the cryptographic public key of the
 Credential Issuer.
-- SHOULD NOT contain personal information about the User who owns
+- SHOULD NOT contain personal information about the User, that isn't already made available to the Credential Verifier, who owns
 the Digital Credential to which the Status Assertion refers.
 
 # Proof of Possession of a Credential

--- a/draft-demarco-oauth-status-assertions.md
+++ b/draft-demarco-oauth-status-assertions.md
@@ -112,7 +112,7 @@ to holders, who can present these to verifier along
 with the corresponding digital credentials.
 The approach outlined in this document
 makes the verifier able to check the status,
-such as the nonb-revocation, of a digital credential
+such as the non-revocation, of a digital credential
 without requiring to query any third-party entities.
 
 --- middle

--- a/draft-demarco-oauth-status-assertions.md
+++ b/draft-demarco-oauth-status-assertions.md
@@ -681,9 +681,9 @@ variety of scenarios.
 Status assertions can be complex, and are not limited to simple boolean information.
 This enables verifier policies to be conditioned on the presence of secured information, instead of the absence of information.
 This section proposes syntax to support complex assertions.
-The `validity` claim MUST be present and be either `true` or `false`.
-The `validity_reasons` claim MAY be present and if present MUST be an object.
-The semantics of the claims within the `validity_reasons` object are determined by the issuer.
+The `credential_status_validity` claim MUST be present and be either `true` or `false`.
+The `credential_status` claim MAY be present and if present MUST be an object.
+The semantics of the claims within the `credential_status` object are determined by the issuer.
 
 An example of a boolean status is:
 

--- a/draft-demarco-oauth-status-assertions.md
+++ b/draft-demarco-oauth-status-assertions.md
@@ -737,7 +737,7 @@ An example of an enumeration status is:
     "credential_hash": "xnlAq6Ma8fgu1z4hdGphJnKLulaVHpLCFeZFUGpQ2dA",
     "credential_hash_alg": "sha-256",
     "credential_status_validity": false,
-    "credential_status": {
+    "credential_status_detail": {
       "state": "suspended", // or "revoked"
     },
     "cnf": {

--- a/draft-demarco-oauth-status-assertions.md
+++ b/draft-demarco-oauth-status-assertions.md
@@ -701,7 +701,7 @@ An example of a boolean status is:
     "credential_hash": "xnlAq6Ma8fgu1z4hdGphJnKLulaVHpLCFeZFUGpQ2dA",
     "credential_hash_alg": "sha-256",
     "credential_status_validity": false,
-    "validity_reasons": {
+    "credential_status": {
       "suspended": true,
     },
     "cnf": {

--- a/draft-demarco-oauth-status-assertions.md
+++ b/draft-demarco-oauth-status-assertions.md
@@ -700,7 +700,7 @@ An example of a boolean status is:
     "exp": 1504785536,
     "credential_hash": "xnlAq6Ma8fgu1z4hdGphJnKLulaVHpLCFeZFUGpQ2dA",
     "credential_hash_alg": "sha-256",
-    "validity": false,
+    "credential_status_validity": false,
     "validity_reasons": {
       "suspended": true,
     },

--- a/draft-demarco-oauth-status-assertions.md
+++ b/draft-demarco-oauth-status-assertions.md
@@ -573,7 +573,7 @@ The Status Assertion MUST contain the parameters defined below.
 | **exp** | UNIX Timestamp with the expiration time of the JWT. It MUST be greater than the value set for `iat`. | {{RFC9126}}, {{RFC7519}}, {{RFC7515}} |
 | **credential_hash** | Hash value of the Digital Credential the Status Assertion is bound to. | this specification |
 | **credential_hash_alg** | The Algorithm used of hashing the Digital Credential to which the Status Assertion is bound. The value SHOULD be set to `sha-256`. | this specification |
-| **credential_status_validity**| Boolean value determining the absolute validity of the Credential to which the Status Assertion is bound | this specification |
+| **credential_status_validity**| Boolean value indicating the absolute validity of the Credential linked to the Status Assertion. This parameter is REQUIRED, and the Verifier MUST verify its presence and value to assess the Credential's validity. | this specification |
 | **cnf** | JSON object containing confirmation methods. The sub-member contained within `cnf` member, such as `jwk` for JWT and `Cose_Key` for CWT, MUST match with the one provided within the related Digital Credential. Other confirmation methods can be utilized when the referenced Digital Credential supports them, in accordance with the relevant standards. | {{RFC7800}} Section 3.1, {{RFC8747}} Section 3.1 |
 
 
@@ -905,7 +905,7 @@ Digital Credential ecosystem.
 
 ## Validity Reasons
 
-Status Assertions may disclose details about the Holder or subject that were not initially committed to during the original Credential issuance. This can potentially expose additional information that was not part of the original credentialing process.
+Depending by the scopes of how the detailed Status Assertions are implemented, these may disclose details about the Holder or subject that were not initially committed to during the original Credential issuance. This can potentially expose additional information that was not part of the original credentialing process.
 Providing a reason that a Digital Credential is no longer valid can be essential to certain use cases, and unacceptable for others
 For example, in a healthcare setting, a patient should not have medical reasons for a suspended credential disclosed in assertions of suspension.
 However, in a supply chain context, a product suspension might benefit from additional information, such as batch or lot information.

--- a/draft-demarco-oauth-status-assertions.md
+++ b/draft-demarco-oauth-status-assertions.md
@@ -705,7 +705,7 @@ An example of a boolean status is:
     "credential_hash": "xnlAq6Ma8fgu1z4hdGphJnKLulaVHpLCFeZFUGpQ2dA",
     "credential_hash_alg": "sha-256",
     "credential_status_validity": false,
-    "credential_status": {
+    "credential_status_detail": {
       "revoked": false,
       "suspended": true,
     },

--- a/draft-demarco-oauth-status-assertions.md
+++ b/draft-demarco-oauth-status-assertions.md
@@ -702,6 +702,7 @@ An example of a boolean status is:
     "credential_hash_alg": "sha-256",
     "credential_status_validity": false,
     "credential_status": {
+      "revoked": false,
       "suspended": true,
     },
     "cnf": {

--- a/draft-demarco-oauth-status-assertions.md
+++ b/draft-demarco-oauth-status-assertions.md
@@ -686,8 +686,8 @@ Status Assertions can introduce a more accurate level of detail, and therefore n
 This enables Verifier policies to be conditioned on the presence of secured information, instead of the absence of information.
 This section proposes syntax to support detailed assertions.
 The `credential_status_validity` claim MUST be present and be either `true` or `false`.
-The `credential_status` claim MAY be present and if present MUST be an object.
-The semantics of the claims within the `credential_status` object are determined by the Credential Issuer.
+The `credential_status_detail` claim MAY be present and if present MUST be an object.
+The semantics of the claims within the `credential_status_detail` object are determined by the Credential Issuer.
 
 An example of a boolean status is:
 
@@ -929,6 +929,15 @@ IANA "JSON Web Token Claims" registry [IANA.JWT] established by {{RFC7519}}.
 *  Claim Description: The Algorithm used of hashing the Digital Credential to which the Status Assertion is bound.
 *  Change Controller: IETF
 *  Specification Document(s): [this specification](#status-assertion)
+
+<br/>
+
+*  Claim Name: `credential_status_detail`
+*  Claim Description: New status information provided by the Issuer.
+*  Change Controller: IETF
+*  Specification Document(s): [this specification](#status-assertion)
+
+
 
 ## Media Type Registration
 

--- a/draft-demarco-oauth-status-assertions.md
+++ b/draft-demarco-oauth-status-assertions.md
@@ -678,12 +678,12 @@ variety of scenarios.
 
 # Detailed Status Assertions
 
-Status assertions can be complex, and are not limited to simple boolean information.
-This enables verifier policies to be conditioned on the presence of secured information, instead of the absence of information.
-This section proposes syntax to support complex assertions.
+Status Assertions can introduce a more accurate level of detail, and therefore not necessarly limited to simple boolean information.
+This enables Verifier policies to be conditioned on the presence of secured information, instead of the absence of information.
+This section proposes syntax to support detailed assertions.
 The `credential_status_validity` claim MUST be present and be either `true` or `false`.
 The `credential_status` claim MAY be present and if present MUST be an object.
-The semantics of the claims within the `credential_status` object are determined by the issuer.
+The semantics of the claims within the `credential_status` object are determined by the Credential Issuer.
 
 An example of a boolean status is:
 
@@ -706,7 +706,6 @@ An example of a boolean status is:
     },
     "cnf": {
       "jwk": {
-        "kid": "1wL9OG_AZOniODhs2xvMchvFcBWhpQPz3uW29LhqvI0",
         "alg": "ES256",
         "kty": "EC",
         "crv": "P-256",
@@ -738,7 +737,6 @@ An example of an enumeration status is:
     },
     "cnf": {
       "jwk": {
-        "kid": "1wL9OG_AZOniODhs2xvMchvFcBWhpQPz3uW29LhqvI0",
         "alg": "ES256",
         "kty": "EC",
         "crv": "P-256",
@@ -770,7 +768,6 @@ An example of dynamic status using a small matrix:
     },
     "cnf": {
       "jwk": {
-        "kid": "1wL9OG_AZOniODhs2xvMchvFcBWhpQPz3uW29LhqvI0",
         "alg": "ES256",
         "kty": "EC",
         "crv": "P-256",
@@ -903,8 +900,8 @@ Digital Credential ecosystem.
 
 ## Validity Reasons
 
-Status assertions can reveal information about the holder or subject that was not commited to in the original credential issuance.
-Providing a reason that a digital credential is no longer valid can be essential to certian use cases, and unacceptable for others.
+Status Assertions may disclose details about the Holder or subject that were not initially committed to during the original Credential issuance. This can potentially expose additional information that was not part of the original credentialing process.
+Providing a reason that a Digital Credential is no longer valid can be essential to certain use cases, and unacceptable for others
 For example, in a healthcare setting, a patient should not have medical reasons for a suspended credential disclosed in assertions of suspension.
 However, in a supply chain context, a product suspension might benefit from additional information, such as batch or lot information.
 

--- a/draft-demarco-oauth-status-assertions.md
+++ b/draft-demarco-oauth-status-assertions.md
@@ -768,7 +768,7 @@ An example of dynamic status using a small matrix:
     "credential_hash": "xnlAq6Ma8fgu1z4hdGphJnKLulaVHpLCFeZFUGpQ2dA",
     "credential_hash_alg": "sha-256",
     "credential_status_validity": true,
-    "credential_status": {
+    "credential_status_detail": {
       "preferences": [[1, 0.25, 0.76 ...] ...]
     },
     "cnf": {

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -580,9 +580,12 @@ variety of scenarios.
 
 # Complex Status Assertions
 
-Issuer's MAY provide an assertion of invalidity, in contrast to an assertion of validity or an error for digital credentials which have been revoked.
+Status assertions can be complex, and are not limited to simple boolean information.
 This enables verifier policies to be conditioned on the presence of secured information, instead of the absence of information.
-Assertions can reflect dynamic information that is not limited to boolean values.
+This section proposes syntax to support complex assertions.
+The `validity` claim MUST be present and be either `true` or `false`.
+The `validity_reasons` MAY be present and if present MUST be an object.
+The semantics of the claims within the `validity_reasons` object are determined by the issuer.
 
 An example of a boolean status is:
 
@@ -604,14 +607,14 @@ An example of a boolean status is:
       "suspended": true,
     },
     "cnf": {
-        "jwk": {
-          "kid": "1wL9OG_AZOniODhs2xvMchvFcBWhpQPz3uW29LhqvI0",
-          "alg": "ES256",
-          "kty": "EC",
-          "crv": "P-256",
-          "x": "_2ySUmWFjwmraNlo15r6dIBXerVdy_NpJuwAKJMFdoc",
-          "y": "MV3C88MhhEMba6oyMBWuGeB3dKHP4YADJmGyJwwILsk"
-        }
+      "jwk": {
+        "kid": "1wL9OG_AZOniODhs2xvMchvFcBWhpQPz3uW29LhqvI0",
+        "alg": "ES256",
+        "kty": "EC",
+        "crv": "P-256",
+        "x": "_2ySUmWFjwmraNlo15r6dIBXerVdy_NpJuwAKJMFdoc",
+        "y": "MV3C88MhhEMba6oyMBWuGeB3dKHP4YADJmGyJwwILsk"
+      }
     }
 }
 ~~~
@@ -633,17 +636,17 @@ An example of an enumeration status is:
     "credential_hash_alg": "sha-256",
     "validity": false,
     "validity_reasons": {
-      "state": "suspended", // or "revoked", or "valid".
+      "state": "suspended", // or "revoked"
     },
     "cnf": {
-        "jwk": {
-          "kid": "1wL9OG_AZOniODhs2xvMchvFcBWhpQPz3uW29LhqvI0",
-          "alg": "ES256",
-          "kty": "EC",
-          "crv": "P-256",
-          "x": "_2ySUmWFjwmraNlo15r6dIBXerVdy_NpJuwAKJMFdoc",
-          "y": "MV3C88MhhEMba6oyMBWuGeB3dKHP4YADJmGyJwwILsk"
-        }
+      "jwk": {
+        "kid": "1wL9OG_AZOniODhs2xvMchvFcBWhpQPz3uW29LhqvI0",
+        "alg": "ES256",
+        "kty": "EC",
+        "crv": "P-256",
+        "x": "_2ySUmWFjwmraNlo15r6dIBXerVdy_NpJuwAKJMFdoc",
+        "y": "MV3C88MhhEMba6oyMBWuGeB3dKHP4YADJmGyJwwILsk"
+      }
     }
 }
 ~~~
@@ -668,14 +671,14 @@ An example of dynamic status using a small matrix:
       "preferences": [[1, 0.25, 0.76 ...] ...]
     },
     "cnf": {
-        "jwk": {
-          "kid": "1wL9OG_AZOniODhs2xvMchvFcBWhpQPz3uW29LhqvI0",
-          "alg": "ES256",
-          "kty": "EC",
-          "crv": "P-256",
-          "x": "_2ySUmWFjwmraNlo15r6dIBXerVdy_NpJuwAKJMFdoc",
-          "y": "MV3C88MhhEMba6oyMBWuGeB3dKHP4YADJmGyJwwILsk"
-        }
+      "jwk": {
+        "kid": "1wL9OG_AZOniODhs2xvMchvFcBWhpQPz3uW29LhqvI0",
+        "alg": "ES256",
+        "kty": "EC",
+        "crv": "P-256",
+        "x": "_2ySUmWFjwmraNlo15r6dIBXerVdy_NpJuwAKJMFdoc",
+        "y": "MV3C88MhhEMba6oyMBWuGeB3dKHP4YADJmGyJwwILsk"
+      }
     }
 }
 ~~~
@@ -799,6 +802,13 @@ the verification process.
 Status Assertions are based on a privacy-by-design approach, reflecting
 a deliberate effort to balance security and privacy needs in the
 Digital Credential ecosystem.
+
+## Validity Reasons
+
+Status assertions can reveal information about the holder or subject that was not commited to in the original credential issuance.
+Providing a reason that a digital credential is no longer valid can be essential to certian use cases, and unacceptable for others.
+For example, in a healthcare setting, a patient should not have have reasons for a suspended credential disclosed in assertions of suspension.
+However, in a supply chain context, a product suspension might benefit from additional information, such as batch or lot information.
 
 # IANA Considerations
 

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -584,7 +584,7 @@ Status assertions can be complex, and are not limited to simple boolean informat
 This enables verifier policies to be conditioned on the presence of secured information, instead of the absence of information.
 This section proposes syntax to support complex assertions.
 The `validity` claim MUST be present and be either `true` or `false`.
-The `validity_reasons` MAY be present and if present MUST be an object.
+The `validity_reasons` claim MAY be present and if present MUST be an object.
 The semantics of the claims within the `validity_reasons` object are determined by the issuer.
 
 An example of a boolean status is:

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -807,7 +807,7 @@ Digital Credential ecosystem.
 
 Status assertions can reveal information about the holder or subject that was not commited to in the original credential issuance.
 Providing a reason that a digital credential is no longer valid can be essential to certian use cases, and unacceptable for others.
-For example, in a healthcare setting, a patient should not have have reasons for a suspended credential disclosed in assertions of suspension.
+For example, in a healthcare setting, a patient should not have medical reasons for a suspended credential disclosed in assertions of suspension.
 However, in a supply chain context, a product suspension might benefit from additional information, such as batch or lot information.
 
 # IANA Considerations

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -588,7 +588,31 @@ An example of a boolean status is:
 
 ~~~
 {
-  "suspended": true,
+    "alg": "ES256",
+    "typ": "status-assertion+jwt",
+    "kid": "w8ZOZRcx21Zpry7H-0VLBsH7Wf7WXb6TeK3qVMCpY44"
+}
+.
+{
+    "iss": "https://issuer.example.org",
+    "iat": 1504699136,
+    "exp": 1504785536,
+    "credential_hash": "xnlAq6Ma8fgu1z4hdGphJnKLulaVHpLCFeZFUGpQ2dA",
+    "credential_hash_alg": "sha-256",
+    "validity": false,
+    "validity_reasons": {
+      "suspended": true,
+    },
+    "cnf": {
+        "jwk": {
+          "kid": "1wL9OG_AZOniODhs2xvMchvFcBWhpQPz3uW29LhqvI0",
+          "alg": "ES256",
+          "kty": "EC",
+          "crv": "P-256",
+          "x": "_2ySUmWFjwmraNlo15r6dIBXerVdy_NpJuwAKJMFdoc",
+          "y": "MV3C88MhhEMba6oyMBWuGeB3dKHP4YADJmGyJwwILsk"
+        }
+    }
 }
 ~~~
 
@@ -596,7 +620,31 @@ An example of an enumeration status is:
 
 ~~~
 {
-  "state": "suspended", // or "revoked", or "valid".
+    "alg": "ES256",
+    "typ": "status-assertion+jwt",
+    "kid": "w8ZOZRcx21Zpry7H-0VLBsH7Wf7WXb6TeK3qVMCpY44"
+}
+.
+{
+    "iss": "https://issuer.example.org",
+    "iat": 1504699136,
+    "exp": 1504785536,
+    "credential_hash": "xnlAq6Ma8fgu1z4hdGphJnKLulaVHpLCFeZFUGpQ2dA",
+    "credential_hash_alg": "sha-256",
+    "validity": false,
+    "validity_reasons": {
+      "state": "suspended", // or "revoked", or "valid".
+    },
+    "cnf": {
+        "jwk": {
+          "kid": "1wL9OG_AZOniODhs2xvMchvFcBWhpQPz3uW29LhqvI0",
+          "alg": "ES256",
+          "kty": "EC",
+          "crv": "P-256",
+          "x": "_2ySUmWFjwmraNlo15r6dIBXerVdy_NpJuwAKJMFdoc",
+          "y": "MV3C88MhhEMba6oyMBWuGeB3dKHP4YADJmGyJwwILsk"
+        }
+    }
 }
 ~~~
 
@@ -604,7 +652,31 @@ An example of dynamic status using a small matrix:
 
 ~~~
 {
-  "preferences": [[1, 0.25, 0.76 ...] ...]
+    "alg": "ES256",
+    "typ": "status-assertion+jwt",
+    "kid": "w8ZOZRcx21Zpry7H-0VLBsH7Wf7WXb6TeK3qVMCpY44"
+}
+.
+{
+    "iss": "https://issuer.example.org",
+    "iat": 1504699136,
+    "exp": 1504785536,
+    "credential_hash": "xnlAq6Ma8fgu1z4hdGphJnKLulaVHpLCFeZFUGpQ2dA",
+    "credential_hash_alg": "sha-256",
+    "validity": true,
+    "validity_reasons": {
+      "preferences": [[1, 0.25, 0.76 ...] ...]
+    },
+    "cnf": {
+        "jwk": {
+          "kid": "1wL9OG_AZOniODhs2xvMchvFcBWhpQPz3uW29LhqvI0",
+          "alg": "ES256",
+          "kty": "EC",
+          "crv": "P-256",
+          "x": "_2ySUmWFjwmraNlo15r6dIBXerVdy_NpJuwAKJMFdoc",
+          "y": "MV3C88MhhEMba6oyMBWuGeB3dKHP4YADJmGyJwwILsk"
+        }
+    }
 }
 ~~~
 

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -578,6 +578,10 @@ may not always coincide with the actual usability of a Digital Credential,
 allowing Verifiers to examine and make educated conclusions based on a
 variety of scenarios.
 
+# Assertions of Invalidity
+
+Issuer's MAY provide an assertion of invalidity, in contrast to an assertion of validity or an error for digital credentials which have been revoked.
+This enables verifier policies to be conditioned on the presence of signed positive or negative state from the issuer, instead of the absence of information.
 
 # Security Considerations
 

--- a/draft-demarco-oauth-status-attestations.md
+++ b/draft-demarco-oauth-status-attestations.md
@@ -578,10 +578,50 @@ may not always coincide with the actual usability of a Digital Credential,
 allowing Verifiers to examine and make educated conclusions based on a
 variety of scenarios.
 
-# Assertions of Invalidity
+# Complex Status Assertions
 
 Issuer's MAY provide an assertion of invalidity, in contrast to an assertion of validity or an error for digital credentials which have been revoked.
-This enables verifier policies to be conditioned on the presence of signed positive or negative state from the issuer, instead of the absence of information.
+This enables verifier policies to be conditioned on the presence of secured information, instead of the absence of information.
+Assertions can reflect dynamic information that is not limited to boolean values.
+
+An example of a boolean status is:
+
+~~~
+{
+  "suspended": true,
+}
+~~~
+
+An example of an enumeration status is:
+
+~~~
+{
+  "state": "suspended", // or "revoked", or "valid".
+}
+~~~
+
+An example of dynamic status using a small matrix:
+
+~~~
+{
+  "preferences": [[1, 0.25, 0.76 ...] ...]
+}
+~~~
+
+An example of multiple assertions:
+
+~~~
+HTTP/1.1 200 Created
+Content-Type: application/json
+
+{
+    "status_assertion_responses": [
+      $JWT_1, // Not revoked, boolean assertion
+      $JWT_2, // alg = none, suspended indicator
+      $JWT_3, // Preferences matrix assertion
+    ]
+}
+~~~
 
 # Security Considerations
 


### PR DESCRIPTION
Addressing:

https://github.com/peppelinux/draft-demarco-oauth-status-attestations/pull/53#discussion_r1614083883

The purpose of this pull request is to define the signed information which can be conveyed to a verifier, to clarify the constraints on verifier policies.

With other status list approaches, there is an ability to communicate a single boolean, multiple boolean, or enumerations.

With our approach here, we are not limited by the bitstring data structure, so dynamic state is less constrained.

This PR also highlights the current design decision to use alg = none, to signal revocation, without providing an assertion that can be consumed by a verifier.

There may be very legitimate reasons to prefer to return unsigned information for boolean status, but for complex status, unsigned information is more dangerous to consume.

I believe the specification should leave some of these decisions up to profiles.