### PR TITLE
added requirements about not specifying the audience of a status assertion

### DIFF
--- a/draft-demarco-oauth-status-assertions.md
+++ b/draft-demarco-oauth-status-assertions.md
@@ -251,7 +251,7 @@ Credential Issuer.
 - MUST NOT contain personal information about the User who owns
 the Digital Credential to which the Status Assertion refers.
 - MUST NOT contain any information regarding the Verifier to whom it may
-be presented, such as the Verifier identifier as the intended audience.
+be presented, such as disclose the Verifier identifier to specify the intended audience.
 
 # Proof of Possession of a Credential
 

--- a/draft-demarco-oauth-status-assertions.md
+++ b/draft-demarco-oauth-status-assertions.md
@@ -250,6 +250,8 @@ a cryptographic signature and the cryptographic public key of the
 Credential Issuer.
 - MUST NOT contain personal information about the User who owns
 the Digital Credential to which the Status Assertion refers.
+- MUST NOT contain any information regarding the Verifier to whom it may
+be presented, such as the Verifier identifier as the intended audience.
 
 # Proof of Possession of a Credential
 


### PR DESCRIPTION
status assertions do not disclose their intended audience to the credential issuers