### PR TITLE
fix: Credential Issuer metadata not necessarly OpenID4VCI

### DIFF
--- a/draft-demarco-oauth-status-assertions.md
+++ b/draft-demarco-oauth-status-assertions.md
@@ -582,7 +582,7 @@ detailing the necessary metadata and practices to integrate into their systems.
 ## Credential Issuer Metadata
 
 The Credential Issuers that uses the Status Assertions MUST include in their
-OpenID4VCI [OpenID4VCI] metadata the claims:
+metadata the following parameters:
 
 - `status_assertion_endpoint`. REQUIRED. It MUST be an HTTPs URL indicating
 the endpoint where the Wallet Instances can request Status Assertions.


### PR DESCRIPTION
this PR resolves https://github.com/peppelinux/draft-demarco-oauth-status-assertions/issues/27